### PR TITLE
Add comprehensive unit tests for domain entities

### DIFF
--- a/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
@@ -25,7 +25,7 @@ class ActivityScheduleTest {
         activity.setOwner(owner);
         activity.setLocation(TestDataFactory.createPoint(5.0, 51.0));
         activity.setColorCode("#111111");
-        activity.setTargetAudience(TargetAudience.ADULTS);
+        activity.setTargetAudience(TargetAudience.STUDENTS);
         activity.setTotalSpaces(8);
     }
 

--- a/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
@@ -1,0 +1,150 @@
+package com.bytser.campso.api.activities;
+
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ActivityScheduleTest {
+
+    private Activity activity;
+
+    @BeforeEach
+    void setUp() {
+        User owner = TestDataFactory.createUser("ScheduleOwner");
+        activity = new TestActivity();
+        activity.setName("Climbing");
+        activity.setOwner(owner);
+        activity.setLocation(TestDataFactory.createPoint(5.0, 51.0));
+        activity.setColorCode("#111111");
+        activity.setTargetAudience(TargetAudience.ADULTS);
+        activity.setTotalSpaces(8);
+    }
+
+    @Test
+    void constructorShouldCopySlotsAndValidate() {
+        List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(10, 0), LocalTime.of(11, 0)));
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), slots);
+
+        assertThat(schedule.getActivity()).isEqualTo(activity);
+        assertThat(schedule.getValidFrom()).isEqualTo(LocalDate.of(2024, 1, 1));
+        assertThat(schedule.getValidTo()).isEqualTo(LocalDate.of(2024, 12, 31));
+        assertThat(schedule.getTimeSlots()).containsExactlyElementsOf(slots);
+    }
+
+    @Test
+    void constructorShouldRejectNullActivity() {
+        List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
+        assertThatThrownBy(() -> new ActivitySchedule(null, LocalDate.now(), LocalDate.now(), slots))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("activity is required");
+    }
+
+    @Test
+    void constructorShouldRejectInvalidDateRange() {
+        List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
+        assertThatThrownBy(() -> new ActivitySchedule(activity, LocalDate.of(2024, 12, 31), LocalDate.of(2024, 1, 1), slots))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("validFrom after validTo");
+    }
+
+    @Test
+    void constructorShouldRejectHalfOpenRange() {
+        List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
+        assertThatThrownBy(() -> new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), null, slots))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must both be null or both non-null");
+    }
+
+    @Test
+    void constructorShouldRejectOverlappingSlots() {
+        List<TimeSlot> slots = List.of(
+                new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)),
+                new TimeSlot(LocalTime.of(9, 30), LocalTime.of(10, 30))
+        );
+        assertThatThrownBy(() -> new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), slots))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("overlapping timeslots");
+    }
+
+    @Test
+    void addTimeSlotShouldAppendSlot() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+        schedule.addTimeSlot(LocalTime.of(8, 0), LocalTime.of(9, 0));
+
+        assertThat(schedule.getTimeSlots())
+                .hasSize(1)
+                .allMatch(slot -> slot.getStartTime().equals(LocalTime.of(8, 0)) && slot.getEndTime().equals(LocalTime.of(9, 0)));
+    }
+
+    @Test
+    void addExceptionShouldStoreUniqueDates() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+        LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
+
+        schedule.addException(exceptionDate);
+
+        assertThat(schedule.getExceptions()).containsExactly(exceptionDate);
+    }
+
+    @Test
+    void addExceptionShouldIgnoreNull() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+
+        schedule.addException(null);
+
+        assertThat(schedule.getExceptions()).isEmpty();
+    }
+
+    @Test
+    void addExceptionShouldRejectDuplicates() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+        LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
+        schedule.addException(exceptionDate);
+
+        assertThatThrownBy(() -> schedule.addException(exceptionDate))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already exists");
+    }
+
+    @Test
+    void removeExceptionShouldBeSafeWhenDateMissing() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+        schedule.addException(LocalDate.of(2024, 5, 1));
+
+        schedule.removeException(LocalDate.of(2024, 6, 1));
+
+        assertThat(schedule.getExceptions()).containsExactly(LocalDate.of(2024, 5, 1));
+    }
+
+    @Test
+    void removeExceptionShouldRemoveExistingDate() {
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
+        LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
+        schedule.addException(exceptionDate);
+
+        schedule.removeException(exceptionDate);
+
+        assertThat(schedule.getExceptions()).isEmpty();
+    }
+
+    @Test
+    void removeTimeSlotShouldDeleteSlot() {
+        TimeSlot slot = new TimeSlot(LocalTime.of(13, 0), LocalTime.of(14, 0));
+        ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of(slot));
+
+        schedule.removeTimeSlot(schedule.getTimeSlots().get(0));
+
+        assertThat(schedule.getTimeSlots()).isEmpty();
+    }
+
+    private static class TestActivity extends Activity {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityScheduleTest.java
@@ -3,6 +3,7 @@ package com.bytser.campso.api.activities;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("constructor copies slots and validates schedule fields")
     void constructorShouldCopySlotsAndValidate() {
         List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(10, 0), LocalTime.of(11, 0)));
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), slots);
@@ -40,6 +42,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("constructor rejects schedules without an activity")
     void constructorShouldRejectNullActivity() {
         List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
         assertThatThrownBy(() -> new ActivitySchedule(null, LocalDate.now(), LocalDate.now(), slots))
@@ -48,6 +51,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("constructor rejects schedules where validFrom is after validTo")
     void constructorShouldRejectInvalidDateRange() {
         List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
         assertThatThrownBy(() -> new ActivitySchedule(activity, LocalDate.of(2024, 12, 31), LocalDate.of(2024, 1, 1), slots))
@@ -56,6 +60,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("constructor rejects half open date ranges")
     void constructorShouldRejectHalfOpenRange() {
         List<TimeSlot> slots = List.of(new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)));
         assertThatThrownBy(() -> new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), null, slots))
@@ -64,6 +69,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("constructor rejects overlapping time slots")
     void constructorShouldRejectOverlappingSlots() {
         List<TimeSlot> slots = List.of(
                 new TimeSlot(LocalTime.of(9, 0), LocalTime.of(10, 0)),
@@ -75,6 +81,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("addTimeSlot appends a new slot with provided start and end times")
     void addTimeSlotShouldAppendSlot() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
         schedule.addTimeSlot(LocalTime.of(8, 0), LocalTime.of(9, 0));
@@ -85,6 +92,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("addException stores unique exception dates")
     void addExceptionShouldStoreUniqueDates() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
         LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
@@ -95,6 +103,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("addException ignores null values")
     void addExceptionShouldIgnoreNull() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
 
@@ -104,6 +113,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("addException rejects duplicate dates")
     void addExceptionShouldRejectDuplicates() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
         LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
@@ -115,6 +125,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("removeException safely ignores dates that were not stored")
     void removeExceptionShouldBeSafeWhenDateMissing() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
         schedule.addException(LocalDate.of(2024, 5, 1));
@@ -125,6 +136,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("removeException removes stored exception dates")
     void removeExceptionShouldRemoveExistingDate() {
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of());
         LocalDate exceptionDate = LocalDate.of(2024, 5, 1);
@@ -136,6 +148,7 @@ class ActivityScheduleTest {
     }
 
     @Test
+    @DisplayName("removeTimeSlot removes the provided time slot instance")
     void removeTimeSlotShouldDeleteSlot() {
         TimeSlot slot = new TimeSlot(LocalTime.of(13, 0), LocalTime.of(14, 0));
         ActivitySchedule schedule = new ActivitySchedule(activity, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31), List.of(slot));

--- a/src/test/java/com/bytser/campso/api/activities/ActivityServiceTests.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityServiceTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.activities;
-
-public class ActivityServiceTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
@@ -1,0 +1,125 @@
+package com.bytser.campso.api.activities;
+
+import com.bytser.campso.api.facilities.Facility;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ActivityTest {
+
+    private Activity activity;
+    private User owner;
+    private Geometry location;
+
+    @BeforeEach
+    void setUp() {
+        owner = TestDataFactory.createUser("ActivityOwner");
+        location = TestDataFactory.createPoint(4.0, 52.0);
+        activity = new TestActivity();
+        activity.setName("Kayaking Adventure");
+        activity.setOwner(owner);
+        activity.setLocation(location);
+        activity.setColorCode("#FF00FF");
+        activity.setInfo("Enjoy a day on the water");
+        activity.setHost("River Guides");
+        activity.setTargetAudience(TargetAudience.FAMILY);
+        activity.setTotalSpaces(12);
+    }
+
+    @Test
+    void addFacilityShouldLinkBothSides() {
+        Facility facility = new TestFacility();
+        facility.setName("Boat House");
+        facility.setOwner(owner);
+        facility.setLocation(location);
+        facility.setColorCode("#123456");
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SPORTS);
+
+        activity.addFacility(facility);
+
+        assertThat(activity.getFacilities()).containsExactly(facility);
+        assertThat(facility.getHostPlace()).isEqualTo(activity);
+    }
+
+    @Test
+    void addFacilityShouldIgnoreNull() {
+        activity.addFacility(null);
+        assertThat(activity.getFacilities()).isEmpty();
+    }
+
+    @Test
+    void removeFacilityShouldUnlinkBothSides() {
+        Facility facility = new TestFacility();
+        facility.setName("Boat House");
+        facility.setOwner(owner);
+        facility.setLocation(location);
+        facility.setColorCode("#123456");
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SPORTS);
+
+        activity.addFacility(facility);
+        activity.removeFacility(facility);
+
+        assertThat(activity.getFacilities()).isEmpty();
+        assertThat(facility.getHostPlace()).isNull();
+    }
+
+    @Test
+    void removeFacilityShouldIgnoreNull() {
+        activity.removeFacility(null);
+        assertThat(activity.getFacilities()).isEmpty();
+    }
+
+    @Test
+    void addScheduleShouldLinkBothSides() {
+        ActivitySchedule schedule = new ActivitySchedule();
+
+        activity.addSchedule(schedule);
+
+        assertThat(activity.getSchedules()).containsExactly(schedule);
+        assertThat(schedule.getActivity()).isEqualTo(activity);
+    }
+
+    @Test
+    void addScheduleShouldIgnoreNull() {
+        activity.addSchedule(null);
+        assertThat(activity.getSchedules()).isEmpty();
+    }
+
+    @Test
+    void removeScheduleShouldUnlinkBothSides() {
+        ActivitySchedule schedule = new ActivitySchedule();
+        activity.addSchedule(schedule);
+
+        activity.removeSchedule(schedule);
+
+        assertThat(activity.getSchedules()).isEmpty();
+        assertThat(schedule.getActivity()).isNull();
+    }
+
+    @Test
+    void removeScheduleShouldIgnoreNull() {
+        activity.removeSchedule(null);
+        assertThat(activity.getSchedules()).isEmpty();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = activity.toString();
+
+        assertThat(asString)
+                .contains("Kayaking Adventure")
+                .contains("River Guides")
+                .contains("FAMILY")
+                .contains("12");
+    }
+
+    private static class TestActivity extends Activity {
+    }
+
+    private static class TestFacility extends Facility {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
@@ -27,7 +27,7 @@ class ActivityTest {
         activity.setColorCode("#FF00FF");
         activity.setInfo("Enjoy a day on the water");
         activity.setHost("River Guides");
-        activity.setTargetAudience(TargetAudience.FAMILY);
+        activity.setTargetAudience(TargetAudience.FAMILIES);
         activity.setTotalSpaces(12);
     }
 
@@ -39,7 +39,7 @@ class ActivityTest {
         facility.setOwner(owner);
         facility.setLocation(location);
         facility.setColorCode("#123456");
-        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SPORTS);
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.OTHER);
 
         activity.addFacility(facility);
 
@@ -62,7 +62,7 @@ class ActivityTest {
         facility.setOwner(owner);
         facility.setLocation(location);
         facility.setColorCode("#123456");
-        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SPORTS);
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.OTHER);
 
         activity.addFacility(facility);
         activity.removeFacility(facility);
@@ -123,7 +123,7 @@ class ActivityTest {
         assertThat(asString)
                 .contains("Kayaking Adventure")
                 .contains("River Guides")
-                .contains("FAMILY")
+                .contains("FAMILIES")
                 .contains("12");
     }
 

--- a/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityTest.java
@@ -4,6 +4,7 @@ import com.bytser.campso.api.facilities.Facility;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 
@@ -31,6 +32,7 @@ class ActivityTest {
     }
 
     @Test
+    @DisplayName("addFacility links the facility with the activity bidirectionally")
     void addFacilityShouldLinkBothSides() {
         Facility facility = new TestFacility();
         facility.setName("Boat House");
@@ -46,12 +48,14 @@ class ActivityTest {
     }
 
     @Test
+    @DisplayName("addFacility ignores null input")
     void addFacilityShouldIgnoreNull() {
         activity.addFacility(null);
         assertThat(activity.getFacilities()).isEmpty();
     }
 
     @Test
+    @DisplayName("removeFacility clears the association on both sides")
     void removeFacilityShouldUnlinkBothSides() {
         Facility facility = new TestFacility();
         facility.setName("Boat House");
@@ -68,12 +72,14 @@ class ActivityTest {
     }
 
     @Test
+    @DisplayName("removeFacility ignores null input")
     void removeFacilityShouldIgnoreNull() {
         activity.removeFacility(null);
         assertThat(activity.getFacilities()).isEmpty();
     }
 
     @Test
+    @DisplayName("addSchedule links the schedule and activity bidirectionally")
     void addScheduleShouldLinkBothSides() {
         ActivitySchedule schedule = new ActivitySchedule();
 
@@ -84,12 +90,14 @@ class ActivityTest {
     }
 
     @Test
+    @DisplayName("addSchedule ignores null input")
     void addScheduleShouldIgnoreNull() {
         activity.addSchedule(null);
         assertThat(activity.getSchedules()).isEmpty();
     }
 
     @Test
+    @DisplayName("removeSchedule removes both sides of the association")
     void removeScheduleShouldUnlinkBothSides() {
         ActivitySchedule schedule = new ActivitySchedule();
         activity.addSchedule(schedule);
@@ -101,12 +109,14 @@ class ActivityTest {
     }
 
     @Test
+    @DisplayName("removeSchedule ignores null input")
     void removeScheduleShouldIgnoreNull() {
         activity.removeSchedule(null);
         assertThat(activity.getSchedules()).isEmpty();
     }
 
     @Test
+    @DisplayName("toString includes name, host, target audience, and capacity")
     void toStringShouldContainKeyFields() {
         String asString = activity.toString();
 

--- a/src/test/java/com/bytser/campso/api/activities/ActivityTests.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.activities;
-
-public class ActivityTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/activities/TimeSlotTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/TimeSlotTest.java
@@ -1,5 +1,6 @@
 package com.bytser.campso.api.activities;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class TimeSlotTest {
 
     @Test
+    @DisplayName("constructor stores start and end times and renders them in toString")
     void constructorShouldStoreStartAndEndTimes() {
         LocalTime start = LocalTime.of(9, 0);
         LocalTime end = LocalTime.of(10, 0);
@@ -22,6 +24,7 @@ class TimeSlotTest {
     }
 
     @Test
+    @DisplayName("constructor rejects end times that are not after the start time")
     void constructorShouldRejectEndBeforeStart() {
         LocalTime start = LocalTime.of(10, 0);
         LocalTime end = LocalTime.of(9, 0);

--- a/src/test/java/com/bytser/campso/api/activities/TimeSlotTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/TimeSlotTest.java
@@ -1,0 +1,33 @@
+package com.bytser.campso.api.activities;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TimeSlotTest {
+
+    @Test
+    void constructorShouldStoreStartAndEndTimes() {
+        LocalTime start = LocalTime.of(9, 0);
+        LocalTime end = LocalTime.of(10, 0);
+
+        TimeSlot slot = new TimeSlot(start, end);
+
+        assertThat(slot.getStartTime()).isEqualTo(start);
+        assertThat(slot.getEndTime()).isEqualTo(end);
+        assertThat(slot.toString()).contains("09:00").contains("10:00");
+    }
+
+    @Test
+    void constructorShouldRejectEndBeforeStart() {
+        LocalTime start = LocalTime.of(10, 0);
+        LocalTime end = LocalTime.of(9, 0);
+
+        assertThatThrownBy(() -> new TimeSlot(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("end <= start");
+    }
+}

--- a/src/test/java/com/bytser/campso/api/campings/CampingTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingTest.java
@@ -26,7 +26,7 @@ class CampingTest {
         camping.setOwner(owner);
         camping.setLocation(location);
         camping.setColorCode("#00AA00");
-        camping.setTargetAudience(TargetAudience.FAMILY);
+        camping.setTargetAudience(TargetAudience.FAMILIES);
         camping.setTotalSpaces(25);
     }
 
@@ -89,7 +89,7 @@ class CampingTest {
         facility.setOwner(owner);
         facility.setLocation(location);
         facility.setColorCode("#CCCCCC");
-        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SANITATION);
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SHOWER);
 
         camping.addFacility(facility);
 
@@ -105,7 +105,7 @@ class CampingTest {
         facility.setOwner(owner);
         facility.setLocation(location);
         facility.setColorCode("#CCCCCC");
-        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SANITATION);
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SHOWER);
 
         camping.addFacility(facility);
         camping.removeFacility(facility);
@@ -137,7 +137,7 @@ class CampingTest {
 
         assertThat(asString)
                 .contains("Forest Retreat")
-                .contains("FAMILY")
+                .contains("FAMILIES")
                 .contains("25");
     }
 

--- a/src/test/java/com/bytser/campso/api/campings/CampingTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingTest.java
@@ -5,6 +5,7 @@ import com.bytser.campso.api.plans.Plan;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 
@@ -30,6 +31,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("addPlan establishes a bidirectional camping-plan association")
     void addPlanShouldLinkBothSides() {
         Plan plan = new TestPlan();
         plan.setName("Weekend Escape");
@@ -46,6 +48,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("removePlan clears the camping-plan association")
     void removePlanShouldUnlinkBothSides() {
         Plan plan = new TestPlan();
         plan.setName("Weekend Escape");
@@ -63,6 +66,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("addPlan ignores null plans")
     void addPlanShouldIgnoreNull() {
         camping.addPlan(null);
 
@@ -70,6 +74,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("removePlan ignores null inputs")
     void removePlanShouldIgnoreNull() {
         camping.removePlan(null);
 
@@ -77,6 +82,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("addFacility links the facility to the camping bidirectionally")
     void addFacilityShouldLinkBothSides() {
         Facility facility = new TestFacility();
         facility.setName("Shower Block");
@@ -92,6 +98,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("removeFacility severs the bidirectional facility link")
     void removeFacilityShouldUnlinkBothSides() {
         Facility facility = new TestFacility();
         facility.setName("Shower Block");
@@ -108,6 +115,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("addFacility ignores null facilities")
     void addFacilityShouldIgnoreNull() {
         camping.addFacility(null);
 
@@ -115,6 +123,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("removeFacility ignores null inputs")
     void removeFacilityShouldIgnoreNull() {
         camping.removeFacility(null);
 
@@ -122,6 +131,7 @@ class CampingTest {
     }
 
     @Test
+    @DisplayName("toString includes name, audience, and capacity details")
     void toStringShouldContainKeyFields() {
         String asString = camping.toString();
 

--- a/src/test/java/com/bytser/campso/api/campings/CampingTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingTest.java
@@ -1,0 +1,142 @@
+package com.bytser.campso.api.campings;
+
+import com.bytser.campso.api.facilities.Facility;
+import com.bytser.campso.api.plans.Plan;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CampingTest {
+
+    private Camping camping;
+    private User owner;
+    private Geometry location;
+
+    @BeforeEach
+    void setUp() {
+        owner = TestDataFactory.createUser("CampingOwner");
+        location = TestDataFactory.createPoint(7.0, 50.0);
+        camping = new TestCamping();
+        camping.setName("Forest Retreat");
+        camping.setOwner(owner);
+        camping.setLocation(location);
+        camping.setColorCode("#00AA00");
+        camping.setTargetAudience(TargetAudience.FAMILY);
+        camping.setTotalSpaces(25);
+    }
+
+    @Test
+    void addPlanShouldLinkBothSides() {
+        Plan plan = new TestPlan();
+        plan.setName("Weekend Escape");
+        plan.setDescription("Two nights");
+        plan.setPricePerNight(89.99);
+        plan.setMaxGuests(4);
+        plan.setAvailable(true);
+        plan.setPetsAllowed(false);
+
+        camping.addPlan(plan);
+
+        assertThat(camping.getPlans()).containsExactly(plan);
+        assertThat(plan.getCamping()).isEqualTo(camping);
+    }
+
+    @Test
+    void removePlanShouldUnlinkBothSides() {
+        Plan plan = new TestPlan();
+        plan.setName("Weekend Escape");
+        plan.setDescription("Two nights");
+        plan.setPricePerNight(89.99);
+        plan.setMaxGuests(4);
+        plan.setAvailable(true);
+        plan.setPetsAllowed(false);
+
+        camping.addPlan(plan);
+        camping.removePlan(plan);
+
+        assertThat(camping.getPlans()).isEmpty();
+        assertThat(plan.getCamping()).isNull();
+    }
+
+    @Test
+    void addPlanShouldIgnoreNull() {
+        camping.addPlan(null);
+
+        assertThat(camping.getPlans()).isEmpty();
+    }
+
+    @Test
+    void removePlanShouldIgnoreNull() {
+        camping.removePlan(null);
+
+        assertThat(camping.getPlans()).isEmpty();
+    }
+
+    @Test
+    void addFacilityShouldLinkBothSides() {
+        Facility facility = new TestFacility();
+        facility.setName("Shower Block");
+        facility.setOwner(owner);
+        facility.setLocation(location);
+        facility.setColorCode("#CCCCCC");
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SANITATION);
+
+        camping.addFacility(facility);
+
+        assertThat(camping.getFacilities()).containsExactly(facility);
+        assertThat(facility.getHostPlace()).isEqualTo(camping);
+    }
+
+    @Test
+    void removeFacilityShouldUnlinkBothSides() {
+        Facility facility = new TestFacility();
+        facility.setName("Shower Block");
+        facility.setOwner(owner);
+        facility.setLocation(location);
+        facility.setColorCode("#CCCCCC");
+        facility.setFacilityType(com.bytser.campso.api.facilities.FacilityType.SANITATION);
+
+        camping.addFacility(facility);
+        camping.removeFacility(facility);
+
+        assertThat(camping.getFacilities()).isEmpty();
+        assertThat(facility.getHostPlace()).isNull();
+    }
+
+    @Test
+    void addFacilityShouldIgnoreNull() {
+        camping.addFacility(null);
+
+        assertThat(camping.getFacilities()).isEmpty();
+    }
+
+    @Test
+    void removeFacilityShouldIgnoreNull() {
+        camping.removeFacility(null);
+
+        assertThat(camping.getFacilities()).isEmpty();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = camping.toString();
+
+        assertThat(asString)
+                .contains("Forest Retreat")
+                .contains("FAMILY")
+                .contains("25");
+    }
+
+    private static class TestCamping extends Camping {
+    }
+
+    private static class TestPlan extends Plan {
+    }
+
+    private static class TestFacility extends Facility {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/campings/CampingTests.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.campings;
-
-public class CampingTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/campings/RatingTests.java
+++ b/src/test/java/com/bytser/campso/api/campings/RatingTests.java
@@ -1,4 +1,0 @@
-package com.bytser.campso.api.campings;
-
-public enum RatingTests {
-}

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
@@ -1,0 +1,72 @@
+package com.bytser.campso.api.facilities;
+
+import com.bytser.campso.api.activities.Activity;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FacilityTest {
+
+    private Facility facility;
+    private User owner;
+    private Geometry location;
+
+    @BeforeEach
+    void setUp() {
+        owner = TestDataFactory.createUser("FacilityOwner");
+        location = TestDataFactory.createPoint(6.0, 53.0);
+        facility = new TestFacility();
+        facility.setName("Community Kitchen");
+        facility.setOwner(owner);
+        facility.setLocation(location);
+        facility.setColorCode("#FFD700");
+        facility.setInfo("Shared cooking space");
+        facility.setFacilityType(FacilityType.DINING);
+    }
+
+    @Test
+    void setHostPlaceShouldLinkFacilityToPlace() {
+        Activity host = new TestActivity();
+        host.setName("Cooking Class");
+        host.setOwner(owner);
+        host.setLocation(location);
+        host.setColorCode("#990000");
+
+        facility.setHostPlace(host);
+
+        assertThat(facility.getHostPlace()).isEqualTo(host);
+    }
+
+    @Test
+    void setHostPlaceNullShouldUnlink() {
+        Activity host = new TestActivity();
+        host.setName("Cooking Class");
+        host.setOwner(owner);
+        host.setLocation(location);
+        host.setColorCode("#990000");
+
+        facility.setHostPlace(host);
+        facility.setHostPlace(null);
+
+        assertThat(facility.getHostPlace()).isNull();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = facility.toString();
+
+        assertThat(asString)
+                .contains("Community Kitchen")
+                .contains("DINING");
+    }
+
+    private static class TestFacility extends Facility {
+    }
+
+    private static class TestActivity extends Activity {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
@@ -4,6 +4,7 @@ import com.bytser.campso.api.activities.Activity;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 
@@ -29,6 +30,7 @@ class FacilityTest {
     }
 
     @Test
+    @DisplayName("setHostPlace assigns an owning place to the facility")
     void setHostPlaceShouldLinkFacilityToPlace() {
         Activity host = new TestActivity();
         host.setName("Cooking Class");
@@ -42,6 +44,7 @@ class FacilityTest {
     }
 
     @Test
+    @DisplayName("setHostPlace with null removes the existing association")
     void setHostPlaceNullShouldUnlink() {
         Activity host = new TestActivity();
         host.setName("Cooking Class");
@@ -56,6 +59,7 @@ class FacilityTest {
     }
 
     @Test
+    @DisplayName("toString includes the facility name and type")
     void toStringShouldContainKeyFields() {
         String asString = facility.toString();
 

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityTest.java
@@ -26,7 +26,7 @@ class FacilityTest {
         facility.setLocation(location);
         facility.setColorCode("#FFD700");
         facility.setInfo("Shared cooking space");
-        facility.setFacilityType(FacilityType.DINING);
+        facility.setFacilityType(FacilityType.ENTRANCE);
     }
 
     @Test
@@ -65,7 +65,7 @@ class FacilityTest {
 
         assertThat(asString)
                 .contains("Community Kitchen")
-                .contains("DINING");
+                .contains("ENTRANCE");
     }
 
     private static class TestFacility extends Facility {

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityTests.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.facilities;
-
-public class FacilityTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/places/PlaceTest.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceTest.java
@@ -1,0 +1,75 @@
+package com.bytser.campso.api.places;
+
+import com.bytser.campso.api.reviews.Rating;
+import com.bytser.campso.api.reviews.Review;
+import com.bytser.campso.api.support.TestDataFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceTest {
+
+    private Place place;
+
+    @BeforeEach
+    void setUp() {
+        place = new TestPlace();
+        place.setName("Hidden Valley");
+        place.setOwner(TestDataFactory.createUser("PlaceOwner"));
+        place.setLocation(TestDataFactory.createPoint(10.0, 55.0));
+        place.setColorCode("#336699");
+        place.setInfo("Remote campsite with river access");
+    }
+
+    @Test
+    void addReviewShouldLinkBothSides() {
+        Review review = new Review();
+        review.setRating(Rating.FIVE);
+        review.setOwner(TestDataFactory.createUser("ReviewWriter"));
+
+        place.addReview(review);
+
+        assertThat(place.getReviews()).containsExactly(review);
+        assertThat(review.getPlace()).isEqualTo(place);
+    }
+
+    @Test
+    void addReviewShouldIgnoreNull() {
+        place.addReview(null);
+
+        assertThat(place.getReviews()).isEmpty();
+    }
+
+    @Test
+    void deleteReviewShouldUnlinkBothSides() {
+        Review review = new Review();
+        review.setRating(Rating.THREE);
+        review.setOwner(TestDataFactory.createUser("ReviewWriter"));
+
+        place.addReview(review);
+        place.deleteReview(review);
+
+        assertThat(place.getReviews()).isEmpty();
+        assertThat(review.getPlace()).isNull();
+    }
+
+    @Test
+    void deleteReviewShouldIgnoreNull() {
+        place.deleteReview(null);
+
+        assertThat(place.getReviews()).isEmpty();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = place.toString();
+
+        assertThat(asString)
+                .contains("Hidden Valley")
+                .contains("#336699");
+    }
+
+    private static class TestPlace extends Place {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/places/PlaceTest.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceTest.java
@@ -4,6 +4,7 @@ import com.bytser.campso.api.reviews.Rating;
 import com.bytser.campso.api.reviews.Review;
 import com.bytser.campso.api.support.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +24,7 @@ class PlaceTest {
     }
 
     @Test
+    @DisplayName("addReview links the review to the place bidirectionally")
     void addReviewShouldLinkBothSides() {
         Review review = new Review();
         review.setRating(Rating.FIVE);
@@ -35,6 +37,7 @@ class PlaceTest {
     }
 
     @Test
+    @DisplayName("addReview ignores null reviews")
     void addReviewShouldIgnoreNull() {
         place.addReview(null);
 
@@ -42,6 +45,7 @@ class PlaceTest {
     }
 
     @Test
+    @DisplayName("deleteReview removes the review and clears the place reference")
     void deleteReviewShouldUnlinkBothSides() {
         Review review = new Review();
         review.setRating(Rating.THREE);
@@ -55,6 +59,7 @@ class PlaceTest {
     }
 
     @Test
+    @DisplayName("deleteReview ignores null inputs")
     void deleteReviewShouldIgnoreNull() {
         place.deleteReview(null);
 
@@ -62,6 +67,7 @@ class PlaceTest {
     }
 
     @Test
+    @DisplayName("toString includes the place name and color code")
     void toStringShouldContainKeyFields() {
         String asString = place.toString();
 

--- a/src/test/java/com/bytser/campso/api/places/PlaceTest.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceTest.java
@@ -27,7 +27,7 @@ class PlaceTest {
     @DisplayName("addReview links the review to the place bidirectionally")
     void addReviewShouldLinkBothSides() {
         Review review = new Review();
-        review.setRating(Rating.FIVE);
+        review.setRating(Rating.FIVE_STAR);
         review.setOwner(TestDataFactory.createUser("ReviewWriter"));
 
         place.addReview(review);
@@ -48,7 +48,7 @@ class PlaceTest {
     @DisplayName("deleteReview removes the review and clears the place reference")
     void deleteReviewShouldUnlinkBothSides() {
         Review review = new Review();
-        review.setRating(Rating.THREE);
+        review.setRating(Rating.THREE_STAR);
         review.setOwner(TestDataFactory.createUser("ReviewWriter"));
 
         place.addReview(review);

--- a/src/test/java/com/bytser/campso/api/places/PlaceTests.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.places;
-
-public class PlaceTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/plans/PlanTest.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanTest.java
@@ -4,6 +4,7 @@ import com.bytser.campso.api.campings.Camping;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +25,7 @@ class PlanTest {
     }
 
     @Test
+    @DisplayName("setCamping associates the plan with a camping")
     void setCampingShouldLinkPlanToCamping() {
         User owner = TestDataFactory.createUser("PlanOwner");
         Camping camping = new TestCamping();
@@ -40,6 +42,7 @@ class PlanTest {
     }
 
     @Test
+    @DisplayName("toString lists plan configuration fields")
     void toStringShouldContainKeyFields() {
         String asString = plan.toString();
 

--- a/src/test/java/com/bytser/campso/api/plans/PlanTest.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanTest.java
@@ -33,7 +33,7 @@ class PlanTest {
         camping.setOwner(owner);
         camping.setLocation(TestDataFactory.createPoint(3.0, 45.0));
         camping.setColorCode("#445566");
-        camping.setTargetAudience(com.bytser.campso.api.campings.TargetAudience.ADULTS);
+        camping.setTargetAudience(com.bytser.campso.api.campings.TargetAudience.SENIORS);
         camping.setTotalSpaces(15);
 
         plan.setCamping(camping);

--- a/src/test/java/com/bytser/campso/api/plans/PlanTest.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanTest.java
@@ -1,0 +1,59 @@
+package com.bytser.campso.api.plans;
+
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlanTest {
+
+    private Plan plan;
+
+    @BeforeEach
+    void setUp() {
+        plan = new TestPlan();
+        plan.setName("Family Package");
+        plan.setDescription("Includes breakfast");
+        plan.setPricePerNight(120.5);
+        plan.setMaxGuests(6);
+        plan.setAvailable(true);
+        plan.setPetsAllowed(true);
+    }
+
+    @Test
+    void setCampingShouldLinkPlanToCamping() {
+        User owner = TestDataFactory.createUser("PlanOwner");
+        Camping camping = new TestCamping();
+        camping.setName("Mountain Base");
+        camping.setOwner(owner);
+        camping.setLocation(TestDataFactory.createPoint(3.0, 45.0));
+        camping.setColorCode("#445566");
+        camping.setTargetAudience(com.bytser.campso.api.campings.TargetAudience.ADULTS);
+        camping.setTotalSpaces(15);
+
+        plan.setCamping(camping);
+
+        assertThat(plan.getCamping()).isEqualTo(camping);
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = plan.toString();
+
+        assertThat(asString)
+                .contains("name='Family Package'")
+                .contains("pricePerNight=120.5")
+                .contains("maxGuests=6")
+                .contains("available=true")
+                .contains("petsAllowed=true");
+    }
+
+    private static class TestPlan extends Plan {
+    }
+
+    private static class TestCamping extends Camping {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/plans/PlanTests.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.plans;
-
-public class PlanTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
@@ -1,0 +1,79 @@
+package com.bytser.campso.api.reviews;
+
+import com.bytser.campso.api.places.Place;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReviewTest {
+
+    private Review review;
+
+    @BeforeEach
+    void setUp() {
+        review = new Review();
+        review.setRating(Rating.FOUR);
+        review.setInfo("Great stay with friendly hosts");
+    }
+
+    @Test
+    void setOwnerShouldLinkReviewToUser() {
+        User owner = TestDataFactory.createUser("ReviewOwner");
+
+        review.setOwner(owner);
+
+        assertThat(review.getOwner()).isEqualTo(owner);
+    }
+
+    @Test
+    void setOwnerNullShouldUnlink() {
+        User owner = TestDataFactory.createUser("ReviewOwner");
+        review.setOwner(owner);
+
+        review.setOwner(null);
+
+        assertThat(review.getOwner()).isNull();
+    }
+
+    @Test
+    void setPlaceShouldLinkReviewToPlace() {
+        Place place = new TestPlace();
+        place.setName("Seaside Camping");
+        place.setOwner(TestDataFactory.createUser("PlaceOwner"));
+        place.setLocation(TestDataFactory.createPoint(1.0, 2.0));
+        place.setColorCode("#ABCDEF");
+
+        review.setPlace(place);
+
+        assertThat(review.getPlace()).isEqualTo(place);
+    }
+
+    @Test
+    void setPlaceNullShouldUnlink() {
+        Place place = new TestPlace();
+        place.setName("Seaside Camping");
+        place.setOwner(TestDataFactory.createUser("PlaceOwner"));
+        place.setLocation(TestDataFactory.createPoint(1.0, 2.0));
+        place.setColorCode("#ABCDEF");
+
+        review.setPlace(place);
+        review.setPlace(null);
+
+        assertThat(review.getPlace()).isNull();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = review.toString();
+
+        assertThat(asString)
+                .contains("FOUR")
+                .contains("Great stay");
+    }
+
+    private static class TestPlace extends Place {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
@@ -16,7 +16,7 @@ class ReviewTest {
     @BeforeEach
     void setUp() {
         review = new Review();
-        review.setRating(Rating.FOUR);
+        review.setRating(Rating.FOUR_STAR);
         review.setInfo("Great stay with friendly hosts");
     }
 

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewTest.java
@@ -4,6 +4,7 @@ import com.bytser.campso.api.places.Place;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +21,7 @@ class ReviewTest {
     }
 
     @Test
+    @DisplayName("setOwner assigns the review author")
     void setOwnerShouldLinkReviewToUser() {
         User owner = TestDataFactory.createUser("ReviewOwner");
 
@@ -29,6 +31,7 @@ class ReviewTest {
     }
 
     @Test
+    @DisplayName("setOwner with null removes the author reference")
     void setOwnerNullShouldUnlink() {
         User owner = TestDataFactory.createUser("ReviewOwner");
         review.setOwner(owner);
@@ -39,6 +42,7 @@ class ReviewTest {
     }
 
     @Test
+    @DisplayName("setPlace associates the review with a place")
     void setPlaceShouldLinkReviewToPlace() {
         Place place = new TestPlace();
         place.setName("Seaside Camping");
@@ -52,6 +56,7 @@ class ReviewTest {
     }
 
     @Test
+    @DisplayName("setPlace with null removes the place association")
     void setPlaceNullShouldUnlink() {
         Place place = new TestPlace();
         place.setName("Seaside Camping");
@@ -66,6 +71,7 @@ class ReviewTest {
     }
 
     @Test
+    @DisplayName("toString includes rating and review summary")
     void toStringShouldContainKeyFields() {
         String asString = review.toString();
 

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewTests.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.reviews;
-
-public class ReviewTests {
-
-}

--- a/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
+++ b/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
@@ -1,0 +1,37 @@
+package com.bytser.campso.api.support;
+
+import com.bytser.campso.api.users.CountryCode;
+import com.bytser.campso.api.users.Language;
+import com.bytser.campso.api.users.User;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public final class TestDataFactory {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    private TestDataFactory() {
+    }
+
+    public static Geometry createPoint(double longitude, double latitude) {
+        return GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
+    }
+
+    public static User createUser(String identifier) {
+        TestUser user = new TestUser();
+        user.setUserName("user" + identifier);
+        user.setFirstName("First" + identifier);
+        user.setLastName("Last" + identifier);
+        user.setEmail("user" + identifier + "@example.com");
+        user.setPasswordHash("hash" + identifier);
+        user.setLanguage(Language.EN);
+        user.setCountryCode(CountryCode.UK);
+        return user;
+    }
+
+    private static class TestUser extends User {
+        // Uses the protected no-arg constructor from User
+    }
+}

--- a/src/test/java/com/bytser/campso/api/users/UserTest.java
+++ b/src/test/java/com/bytser/campso/api/users/UserTest.java
@@ -5,6 +5,7 @@ import com.bytser.campso.api.reviews.Rating;
 import com.bytser.campso.api.reviews.Review;
 import com.bytser.campso.api.support.TestDataFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -25,6 +26,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("addReview links the review to the user")
     void addReviewShouldLinkBothSides() {
         Review review = new Review();
         review.setRating(Rating.FIVE);
@@ -36,6 +38,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("addReview ignores null reviews")
     void addReviewShouldIgnoreNull() {
         user.addReview(null);
 
@@ -43,6 +46,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("removeReview removes the review and clears owner")
     void removeReviewShouldUnlinkBothSides() {
         Review review = new Review();
         review.setRating(Rating.THREE);
@@ -55,6 +59,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("removeReview ignores null inputs")
     void removeReviewShouldIgnoreNull() {
         user.removeReview(null);
 
@@ -62,6 +67,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("addPlace links the place to the user")
     void addPlaceShouldLinkBothSides() {
         Place place = new TestPlace();
         place.setName("Lakeside");
@@ -75,6 +81,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("addPlace ignores null places")
     void addPlaceShouldIgnoreNull() {
         user.addPlace(null);
 
@@ -82,6 +89,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("removePlace removes the place and clears owner")
     void removePlaceShouldUnlinkBothSides() {
         Place place = new TestPlace();
         place.setName("Lakeside");
@@ -96,6 +104,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("removePlace ignores null inputs")
     void removePlaceShouldIgnoreNull() {
         user.removePlace(null);
 
@@ -103,6 +112,7 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("toString includes username, role, status, and avatar")
     void toStringShouldContainKeyFields() {
         String asString = user.toString();
 

--- a/src/test/java/com/bytser/campso/api/users/UserTest.java
+++ b/src/test/java/com/bytser/campso/api/users/UserTest.java
@@ -29,7 +29,7 @@ class UserTest {
     @DisplayName("addReview links the review to the user")
     void addReviewShouldLinkBothSides() {
         Review review = new Review();
-        review.setRating(Rating.FIVE);
+        review.setRating(Rating.FIVE_STAR);
 
         user.addReview(review);
 
@@ -49,7 +49,7 @@ class UserTest {
     @DisplayName("removeReview removes the review and clears owner")
     void removeReviewShouldUnlinkBothSides() {
         Review review = new Review();
-        review.setRating(Rating.THREE);
+        review.setRating(Rating.THREE_HALF_STAR);
 
         user.addReview(review);
         user.removeReview(review);

--- a/src/test/java/com/bytser/campso/api/users/UserTest.java
+++ b/src/test/java/com/bytser/campso/api/users/UserTest.java
@@ -1,0 +1,118 @@
+package com.bytser.campso.api.users;
+
+import com.bytser.campso.api.places.Place;
+import com.bytser.campso.api.reviews.Rating;
+import com.bytser.campso.api.reviews.Review;
+import com.bytser.campso.api.support.TestDataFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = TestDataFactory.createUser("Main");
+        user.setDateOfBirth(LocalDate.of(1990, 1, 1));
+        user.setProfilePictureUrl("https://example.com/avatar.png");
+        user.setRole(UserRole.ADMIN);
+        user.setStatus(UserStatus.ACTIVE);
+    }
+
+    @Test
+    void addReviewShouldLinkBothSides() {
+        Review review = new Review();
+        review.setRating(Rating.FIVE);
+
+        user.addReview(review);
+
+        assertThat(user.getReviews()).containsExactly(review);
+        assertThat(review.getOwner()).isEqualTo(user);
+    }
+
+    @Test
+    void addReviewShouldIgnoreNull() {
+        user.addReview(null);
+
+        assertThat(user.getReviews()).isEmpty();
+    }
+
+    @Test
+    void removeReviewShouldUnlinkBothSides() {
+        Review review = new Review();
+        review.setRating(Rating.THREE);
+
+        user.addReview(review);
+        user.removeReview(review);
+
+        assertThat(user.getReviews()).isEmpty();
+        assertThat(review.getOwner()).isNull();
+    }
+
+    @Test
+    void removeReviewShouldIgnoreNull() {
+        user.removeReview(null);
+
+        assertThat(user.getReviews()).isEmpty();
+    }
+
+    @Test
+    void addPlaceShouldLinkBothSides() {
+        Place place = new TestPlace();
+        place.setName("Lakeside");
+        place.setLocation(TestDataFactory.createPoint(2.0, 46.0));
+        place.setColorCode("#123123");
+
+        user.addPlace(place);
+
+        assertThat(user.getPlaces()).containsExactly(place);
+        assertThat(place.getOwner()).isEqualTo(user);
+    }
+
+    @Test
+    void addPlaceShouldIgnoreNull() {
+        user.addPlace(null);
+
+        assertThat(user.getPlaces()).isEmpty();
+    }
+
+    @Test
+    void removePlaceShouldUnlinkBothSides() {
+        Place place = new TestPlace();
+        place.setName("Lakeside");
+        place.setLocation(TestDataFactory.createPoint(2.0, 46.0));
+        place.setColorCode("#123123");
+
+        user.addPlace(place);
+        user.removePlace(place);
+
+        assertThat(user.getPlaces()).isEmpty();
+        assertThat(place.getOwner()).isNull();
+    }
+
+    @Test
+    void removePlaceShouldIgnoreNull() {
+        user.removePlace(null);
+
+        assertThat(user.getPlaces()).isEmpty();
+    }
+
+    @Test
+    void toStringShouldContainKeyFields() {
+        String asString = user.toString();
+
+        assertThat(asString)
+                .contains(user.getUserName())
+                .contains("ADMIN")
+                .contains("ACTIVE")
+                .contains("avatar.png");
+    }
+
+    private static class TestPlace extends Place {
+    }
+}

--- a/src/test/java/com/bytser/campso/api/users/UserTests.java
+++ b/src/test/java/com/bytser/campso/api/users/UserTests.java
@@ -1,5 +1,0 @@
-package com.bytser.campso.api.users;
-
-public class UserTests {
-
-}


### PR DESCRIPTION
## Summary
- add unit tests covering Activity, ActivitySchedule, and TimeSlot validation and relationships
- cover Camping, Facility, Plan, Place, Review, and User helper methods including null-handling guards
- introduce a shared TestDataFactory for reusable geometry and user fixtures

## Testing
- `mvn -q test` *(fails: unable to resolve spring-boot-starter-parent 3.5.7 from Maven Central due to HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69120c59569c832584a16dc2a947f83f)