### PR TITLE
Add comprehensive repository integration tests

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,9 +14,9 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 
 # Sensitive data variables and variables that change regulary, get stored in the server environment variables
-server.port=${API_PORT}
+server.port=${API_PORT:8080}
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 # Base folder where uploaded files will be stored
-media.storage.location=${STORAGE_LOC}
+media.storage.location=${STORAGE_LOC:./media}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,10 +13,10 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 
-# Sensitive data variables and variables that change regularly get stored in the server environment variables
-server.port=${API_PORT:8080}
-spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/campso}
-spring.datasource.username=${DB_USERNAME:campso}
-spring.datasource.password=${DB_PASSWORD:campso}
+# Sensitive data variables and variables that change regulary, get stored in the server environment variables
+server.port=${API_PORT}
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 # Base folder where uploaded files will be stored
-media.storage.location=${STORAGE_LOC:./media}
+media.storage.location=${STORAGE_LOC}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,10 +13,10 @@ spring.jpa.open-in-view=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 
-# Sensitive data variables and variables that change regulary, get stored in the server environment variables 
-server.port=${API_PORT}
-spring.datasource.url=${DB_URL}
-spring.datasource.username=${DB_USERNAME}
-spring.datasource.password=${DB_PASSWORD}
+# Sensitive data variables and variables that change regularly get stored in the server environment variables
+server.port=${API_PORT:8080}
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/campso}
+spring.datasource.username=${DB_USERNAME:campso}
+spring.datasource.password=${DB_PASSWORD:campso}
 # Base folder where uploaded files will be stored
-media.storage.location=${STORAGE_LOC} 
+media.storage.location=${STORAGE_LOC:./media}

--- a/src/test/java/com/bytser/campso/api/activities/ActivityRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityRepositoryTest.java
@@ -91,7 +91,7 @@ class ActivityRepositoryTest {
     }
 
     private Activity persistActivity(User owner, String name, double longitude, String host) {
-        Activity activity = new Activity();
+        Activity activity = TestDataFactory.newActivity();
         activity.setName(name);
         activity.setOwner(owner);
         activity.setColorCode("#112233");

--- a/src/test/java/com/bytser/campso/api/activities/ActivityRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/activities/ActivityRepositoryTest.java
@@ -1,30 +1,109 @@
 package com.bytser.campso.api.activities;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class ActivityRepositoryTest {
-    
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class ActivityRepositoryTest {
+
+    @Autowired
+    private ActivityRepository activityRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByName should return all activities with the requested name")
+    void shouldFindActivitiesByName() {
+        User owner = persistUser("700");
+        Activity first = persistActivity(owner, "Kayak Adventure", 60.0, "Host A");
+        Activity second = persistActivity(owner, "Kayak Adventure", 61.0, "Host B");
+        persistActivity(owner, "Hiking Trail", 62.0, "Host C");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Activity> result = activityRepository.findByName("Kayak Adventure");
+
+        assertThat(result)
+            .extracting(Activity::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByOwnerId should return every activity that belongs to the owner")
+    void shouldFindActivitiesByOwnerId() {
+        User owner = persistUser("710");
+        User other = persistUser("711");
+        Activity first = persistActivity(owner, "Mountain Biking", 63.0, "Host D");
+        Activity second = persistActivity(owner, "Cliff Diving", 64.0, "Host E");
+        persistActivity(other, "City Tour", 65.0, "Host F");
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Activity> result = activityRepository.findByOwnerId(owner.getId());
+
+        assertThat(result)
+            .extracting(Activity::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
+    @Test
+    @DisplayName("findByHost should return activities hosted by the provided host")
+    void shouldFindActivitiesByHost() {
+        User owner = persistUser("720");
+        persistActivity(owner, "Sunrise Yoga", 66.0, "Host Yoga");
+        persistActivity(owner, "Evening Yoga", 67.0, "Host Yoga");
+        persistActivity(owner, "Cooking Class", 68.0, "Chef Anna");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Activity> result = activityRepository.findByHost("Host Yoga");
+
+        assertThat(result)
+            .extracting(Activity::getName)
+            .containsExactlyInAnyOrder("Sunrise Yoga", "Evening Yoga");
+        assertThat(result).allMatch(activity -> "Host Yoga".equals(activity.getHost()));
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("findByHost should return an empty list when the host has no activities")
+    void shouldReturnEmptyListWhenHostUnknown() {
+        persistActivity(persistUser("730"), "Rock Climbing", 69.0, "Host G");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Activity> result = activityRepository.findByHost("missing");
+
+        assertThat(result).isEmpty();
+    }
+
+    private Activity persistActivity(User owner, String name, double longitude, String host) {
+        Activity activity = new Activity();
+        activity.setName(name);
+        activity.setOwner(owner);
+        activity.setColorCode("#112233");
+        activity.setLocation(TestDataFactory.createPoint(longitude, 13.0));
+        activity.setInfo("Info for " + name);
+        activity.setTargetAudience(TargetAudience.MIXED);
+        activity.setTotalSpaces(25);
+        activity.setHost(host);
+        return entityManager.persist(activity);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
+    }
 }

--- a/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
@@ -2,7 +2,6 @@ package com.bytser.campso.api.campings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.bytser.campso.api.campings.TargetAudience;
 import com.bytser.campso.api.support.TestDataFactory;
 import com.bytser.campso.api.users.User;
 import java.util.List;

--- a/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
@@ -1,29 +1,90 @@
 package com.bytser.campso.api.campings;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.campings.TargetAudience;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class CampingRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class CampingRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private CampingRepository campingRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByName should return all campings that share the requested name")
+    void shouldFindCampingsByName() {
+        User owner = persistUser("600");
+        Camping first = persistCamping(owner, "Sunset Escape", 50.0);
+        Camping second = persistCamping(owner, "Sunset Escape", 51.0);
+        persistCamping(owner, "Mountain Base", 52.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Camping> result = campingRepository.findByName("Sunset Escape");
+
+        assertThat(result)
+            .extracting(Camping::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByOwnerId should return every camping owned by the user")
+    void shouldFindCampingsByOwnerId() {
+        User owner = persistUser("610");
+        User otherOwner = persistUser("611");
+        Camping first = persistCamping(owner, "Riverfront", 53.0);
+        Camping second = persistCamping(owner, "Forest Retreat", 54.0);
+        persistCamping(otherOwner, "City Base", 55.0);
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Camping> result = campingRepository.findByOwnerId(owner.getId());
+
+        assertThat(result)
+            .extracting(Camping::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
+    }
+
+    @Test
+    @DisplayName("findByOwnerId should return an empty list when no campings match")
+    void shouldReturnEmptyListForUnknownOwner() {
+        persistCamping(persistUser("620"), "Hidden Cove", 56.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Camping> result = campingRepository.findByOwnerId(UUID.randomUUID());
+
+        assertThat(result).isEmpty();
+    }
+
+    private Camping persistCamping(User owner, String name, double longitude) {
+        Camping camping = new Camping();
+        camping.setName(name);
+        camping.setOwner(owner);
+        camping.setColorCode("#abcdef");
+        camping.setLocation(TestDataFactory.createPoint(longitude, 12.0));
+        camping.setInfo("Info for " + name);
+        camping.setTargetAudience(TargetAudience.FAMILIES);
+        camping.setTotalSpaces(40);
+        return entityManager.persist(camping);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
     }
 }

--- a/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/campings/CampingRepositoryTest.java
@@ -73,7 +73,7 @@ class CampingRepositoryTest {
     }
 
     private Camping persistCamping(User owner, String name, double longitude) {
-        Camping camping = new Camping();
+        Camping camping = TestDataFactory.newCamping();
         camping.setName(name);
         camping.setOwner(owner);
         camping.setColorCode("#abcdef");

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityRepositoryTest.java
@@ -78,7 +78,7 @@ class FacilityRepositoryTest {
     }
 
     private Camping persistCamping(User owner, String name, double longitude) {
-        Camping camping = new Camping();
+        Camping camping = TestDataFactory.newCamping();
         camping.setName(name);
         camping.setOwner(owner);
         camping.setColorCode("#abcdef");
@@ -90,7 +90,7 @@ class FacilityRepositoryTest {
     }
 
     private Facility persistFacility(User owner, Camping host, String name, FacilityType type, double longitude) {
-        Facility facility = new Facility();
+        Facility facility = TestDataFactory.newFacility();
         facility.setName(name);
         facility.setOwner(owner);
         facility.setColorCode("#445566");

--- a/src/test/java/com/bytser/campso/api/facilities/FacilityRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/facilities/FacilityRepositoryTest.java
@@ -1,30 +1,107 @@
 package com.bytser.campso.api.facilities;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.campings.TargetAudience;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class FacilityRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class FacilityRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private FacilityRepository facilityRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByHostPlaceId should return every facility attached to the host place")
+    void shouldFindFacilitiesByHostPlaceId() {
+        User owner = persistUser("900");
+        Camping host = persistCamping(owner, "Central Park", 80.0);
+        Camping otherHost = persistCamping(owner, "North Base", 81.0);
+        Facility restroom = persistFacility(owner, host, "Restroom", FacilityType.RESTROOM, 80.0);
+        Facility shower = persistFacility(owner, host, "Shower", FacilityType.SHOWER, 80.1);
+        persistFacility(owner, otherHost, "Parking", FacilityType.PARKING, 81.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Facility> result = facilityRepository.findByHostPlaceId(host.getId());
+
+        assertThat(result)
+            .extracting(Facility::getId)
+            .containsExactlyInAnyOrder(restroom.getId(), shower.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByHostPlaceIdAndFacilityType should return facilities of that type for the host")
+    void shouldFindFacilitiesByHostAndType() {
+        User owner = persistUser("910");
+        Camping host = persistCamping(owner, "Beach Front", 82.0);
+        persistFacility(owner, host, "Wifi", FacilityType.WIFI, 82.0);
+        Facility firstPlayground = persistFacility(owner, host, "Playground", FacilityType.PLAYGROUND, 82.1);
+        Facility secondPlayground = persistFacility(owner, host, "Second Playground", FacilityType.PLAYGROUND, 82.2);
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Facility> result = facilityRepository.findByHostPlaceIdAndFacilityType(host.getId(), FacilityType.PLAYGROUND);
+
+        assertThat(result)
+            .extracting(Facility::getId)
+            .containsExactlyInAnyOrder(firstPlayground.getId(), secondPlayground.getId());
+        assertThat(result)
+            .allMatch(facility -> facility.getFacilityType() == FacilityType.PLAYGROUND);
     }
 
+    @Test
+    @DisplayName("findByHostPlaceId should return an empty list when the host has no facilities")
+    void shouldReturnEmptyFacilitiesWhenHostUnknown() {
+        persistFacility(persistUser("920"), persistCamping(persistUser("921"), "Hidden", 83.0), "Trash", FacilityType.TRASH_DISPOSAL, 83.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Facility> result = facilityRepository.findByHostPlaceId(UUID.randomUUID());
+
+        assertThat(result).isEmpty();
+    }
+
+    private Camping persistCamping(User owner, String name, double longitude) {
+        Camping camping = new Camping();
+        camping.setName(name);
+        camping.setOwner(owner);
+        camping.setColorCode("#abcdef");
+        camping.setLocation(TestDataFactory.createPoint(longitude, 15.0));
+        camping.setInfo("Info for " + name);
+        camping.setTargetAudience(TargetAudience.FAMILIES);
+        camping.setTotalSpaces(45);
+        return entityManager.persist(camping);
+    }
+
+    private Facility persistFacility(User owner, Camping host, String name, FacilityType type, double longitude) {
+        Facility facility = new Facility();
+        facility.setName(name);
+        facility.setOwner(owner);
+        facility.setColorCode("#445566");
+        facility.setLocation(TestDataFactory.createPoint(longitude, 15.5));
+        facility.setInfo("Facility info " + name);
+        facility.setFacilityType(type);
+        facility.setHostPlace(host);
+        return entityManager.persist(facility);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
+    }
 }

--- a/src/test/java/com/bytser/campso/api/places/PlaceRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceRepositoryTest.java
@@ -61,7 +61,7 @@ class PlaceRepositoryTest {
     }
 
     private Activity persistActivity(User owner, String name, double longitude) {
-        Activity activity = new Activity();
+        Activity activity = TestDataFactory.newActivity();
         activity.setName(name);
         activity.setOwner(owner);
         activity.setColorCode("#123456");
@@ -74,7 +74,7 @@ class PlaceRepositoryTest {
     }
 
     private Camping persistCamping(User owner, String name, double longitude) {
-        Camping camping = new Camping();
+        Camping camping = TestDataFactory.newCamping();
         camping.setName(name);
         camping.setOwner(owner);
         camping.setColorCode("#654321");

--- a/src/test/java/com/bytser/campso/api/places/PlaceRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/places/PlaceRepositoryTest.java
@@ -1,30 +1,91 @@
 package com.bytser.campso.api.places;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.activities.Activity;
+import com.bytser.campso.api.activities.TargetAudience;
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class PlaceRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class PlaceRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private PlaceRepository placeRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByName should return all places with the same name regardless of type")
+    void shouldFindPlacesByName() {
+        User owner = persistUser("500");
+        Activity activity = persistActivity(owner, "Trail Camp", 40.0);
+        Camping camping = persistCamping(owner, "Trail Camp", 41.0);
+        persistActivity(owner, "Lakeside", 42.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Place> result = placeRepository.findByName("Trail Camp");
+
+        assertThat(result)
+            .extracting(Place::getId)
+            .containsExactlyInAnyOrder(activity.getId(), camping.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByOwnerId should return every place that belongs to the owner")
+    void shouldFindPlacesByOwnerId() {
+        User firstOwner = persistUser("510");
+        User secondOwner = persistUser("511");
+        Activity first = persistActivity(firstOwner, "Woodland", 45.0);
+        Camping second = persistCamping(firstOwner, "Forest Base", 46.0);
+        persistActivity(secondOwner, "Downtown", 47.0);
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Place> result = placeRepository.findByOwnerId(firstOwner.getId());
+
+        assertThat(result)
+            .extracting(Place::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
+    private Activity persistActivity(User owner, String name, double longitude) {
+        Activity activity = new Activity();
+        activity.setName(name);
+        activity.setOwner(owner);
+        activity.setColorCode("#123456");
+        activity.setLocation(TestDataFactory.createPoint(longitude, 10.0));
+        activity.setInfo("Info " + name);
+        activity.setHost("Host " + name);
+        activity.setTargetAudience(TargetAudience.FAMILIES);
+        activity.setTotalSpaces(20);
+        return entityManager.persist(activity);
+    }
+
+    private Camping persistCamping(User owner, String name, double longitude) {
+        Camping camping = new Camping();
+        camping.setName(name);
+        camping.setOwner(owner);
+        camping.setColorCode("#654321");
+        camping.setLocation(TestDataFactory.createPoint(longitude, 11.0));
+        camping.setInfo("Info " + name);
+        camping.setTargetAudience(com.bytser.campso.api.campings.TargetAudience.MIXED);
+        camping.setTotalSpaces(30);
+        return entityManager.persist(camping);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
+    }
 }

--- a/src/test/java/com/bytser/campso/api/plans/PlanRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanRepositoryTest.java
@@ -80,7 +80,7 @@ class PlanRepositoryTest {
     }
 
     private Camping persistCamping(User owner, String name, double longitude) {
-        Camping camping = new Camping();
+        Camping camping = TestDataFactory.newCamping();
         camping.setName(name);
         camping.setOwner(owner);
         camping.setColorCode("#d4d4d4");
@@ -92,7 +92,7 @@ class PlanRepositoryTest {
     }
 
     private Plan persistPlan(Camping camping, String name, double price) {
-        Plan plan = new Plan();
+        Plan plan = TestDataFactory.newPlan();
         plan.setCamping(camping);
         plan.setName(name);
         plan.setDescription(name + " plan");

--- a/src/test/java/com/bytser/campso/api/plans/PlanRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/plans/PlanRepositoryTest.java
@@ -1,30 +1,109 @@
 package com.bytser.campso.api.plans;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.campings.TargetAudience;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class PlanRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class PlanRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private PlanRepository planRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByCampingId should return all plans that belong to the camping")
+    void shouldFindPlansByCampingId() {
+        User owner = persistUser("800");
+        Camping camping = persistCamping(owner, "Lakeside", 70.0);
+        Camping otherCamping = persistCamping(owner, "Mountain", 71.0);
+        Plan first = persistPlan(camping, "Standard", 50.0);
+        Plan second = persistPlan(camping, "Premium", 80.0);
+        persistPlan(otherCamping, "Budget", 30.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Plan> result = planRepository.findByCampingId(camping.getId());
+
+        assertThat(result)
+            .extracting(Plan::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByCampingIdAndName should return the single matching plan")
+    void shouldFindPlansByCampingIdAndName() {
+        User owner = persistUser("810");
+        Camping camping = persistCamping(owner, "Forest", 72.0);
+        Plan expected = persistPlan(camping, "Deluxe", 120.0);
+        persistPlan(camping, "Economy", 40.0);
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Plan> result = planRepository.findByCampingIdAndName(camping.getId(), "Deluxe");
+
+        assertThat(result)
+            .singleElement()
+            .satisfies(plan -> {
+                assertThat(plan.getId()).isEqualTo(expected.getId());
+                assertThat(plan.getName()).isEqualTo("Deluxe");
+                assertThat(plan.getPricePerNight()).isEqualTo(120.0);
+            });
     }
 
+    @Test
+    @DisplayName("findByCampingIdAndName should return empty when the name does not exist")
+    void shouldReturnEmptyListWhenPlanNameMissing() {
+        User owner = persistUser("820");
+        Camping camping = persistCamping(owner, "River", 73.0);
+        persistPlan(camping, "Explorer", 90.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Plan> result = planRepository.findByCampingIdAndName(camping.getId(), "Unknown");
+
+        assertThat(result).isEmpty();
+    }
+
+    private Camping persistCamping(User owner, String name, double longitude) {
+        Camping camping = new Camping();
+        camping.setName(name);
+        camping.setOwner(owner);
+        camping.setColorCode("#d4d4d4");
+        camping.setLocation(TestDataFactory.createPoint(longitude, 14.0));
+        camping.setInfo("Info for " + name);
+        camping.setTargetAudience(TargetAudience.MIXED);
+        camping.setTotalSpaces(60);
+        return entityManager.persist(camping);
+    }
+
+    private Plan persistPlan(Camping camping, String name, double price) {
+        Plan plan = new Plan();
+        plan.setCamping(camping);
+        plan.setName(name);
+        plan.setDescription(name + " plan");
+        plan.setPricePerNight(price);
+        plan.setMaxGuests(4);
+        plan.setAvailable(true);
+        plan.setPetsAllowed(false);
+        return entityManager.persist(plan);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
+    }
 }

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewRepositoryTest.java
@@ -82,7 +82,7 @@ class ReviewRepositoryTest {
     }
 
     private Camping persistCamping(User owner, String name, double longitude) {
-        Camping camping = new Camping();
+        Camping camping = TestDataFactory.newCamping();
         camping.setName(name);
         camping.setOwner(owner);
         camping.setColorCode("#778899");
@@ -94,7 +94,7 @@ class ReviewRepositoryTest {
     }
 
     private Review persistReview(User owner, Camping camping, Rating rating, String info) {
-        Review review = new Review();
+        Review review = TestDataFactory.newReview();
         review.setOwner(owner);
         review.setPlace(camping);
         review.setRating(rating);

--- a/src/test/java/com/bytser/campso/api/reviews/ReviewRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/reviews/ReviewRepositoryTest.java
@@ -1,30 +1,108 @@
 package com.bytser.campso.api.reviews;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.campings.TargetAudience;
+import com.bytser.campso.api.support.TestDataFactory;
+import com.bytser.campso.api.users.User;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class ReviewRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class ReviewRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByPlaceId should return all reviews for the place")
+    void shouldFindReviewsByPlaceId() {
+        User owner = persistUser("1000");
+        User reviewer = persistUser("1001");
+        Camping camping = persistCamping(owner, "Blue Lake", 90.0);
+        Camping otherCamping = persistCamping(owner, "Green Hill", 91.0);
+        Review first = persistReview(reviewer, camping, Rating.FIVE_STAR, "Amazing");
+        Review second = persistReview(reviewer, camping, Rating.FOUR_STAR, "Great");
+        persistReview(reviewer, otherCamping, Rating.THREE_STAR, "Average");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Review> result = reviewRepository.findByPlaceId(camping.getId());
+
+        assertThat(result)
+            .extracting(Review::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByOwnerId should return all reviews authored by the user")
+    void shouldFindReviewsByOwnerId() {
+        User owner = persistUser("1010");
+        User reviewer = persistUser("1011");
+        User otherReviewer = persistUser("1012");
+        Camping camping = persistCamping(owner, "Sunrise Spot", 92.0);
+        Review first = persistReview(reviewer, camping, Rating.FIVE_STAR, "Excellent");
+        Review second = persistReview(reviewer, camping, Rating.TWO_STAR, "Needs work");
+        persistReview(otherReviewer, camping, Rating.ONE_STAR, "Bad");
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        entityManager.flush();
+        entityManager.clear();
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        List<Review> result = reviewRepository.findByOwnerId(reviewer.getId());
+
+        assertThat(result)
+            .extracting(Review::getId)
+            .containsExactlyInAnyOrder(first.getId(), second.getId());
     }
 
+    @Test
+    @DisplayName("findByOwnerId should return an empty list when the user has not authored reviews")
+    void shouldReturnEmptyListWhenReviewerUnknown() {
+        User owner = persistUser("1020");
+        User reviewer = persistUser("1021");
+        Camping camping = persistCamping(owner, "Forest Retreat", 93.0);
+        persistReview(reviewer, camping, Rating.THREE_STAR, "Good");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Review> result = reviewRepository.findByOwnerId(UUID.randomUUID());
+
+        assertThat(result).isEmpty();
+    }
+
+    private Camping persistCamping(User owner, String name, double longitude) {
+        Camping camping = new Camping();
+        camping.setName(name);
+        camping.setOwner(owner);
+        camping.setColorCode("#778899");
+        camping.setLocation(TestDataFactory.createPoint(longitude, 16.0));
+        camping.setInfo("Info for " + name);
+        camping.setTargetAudience(TargetAudience.MIXED);
+        camping.setTotalSpaces(50);
+        return entityManager.persist(camping);
+    }
+
+    private Review persistReview(User owner, Camping camping, Rating rating, String info) {
+        Review review = new Review();
+        review.setOwner(owner);
+        review.setPlace(camping);
+        review.setRating(rating);
+        review.setInfo(info);
+        return entityManager.persist(review);
+    }
+
+    private User persistUser(String identifier) {
+        return entityManager.persist(TestDataFactory.createUser(identifier));
+    }
 }

--- a/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
+++ b/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
@@ -1,5 +1,10 @@
 package com.bytser.campso.api.support;
 
+import com.bytser.campso.api.activities.Activity;
+import com.bytser.campso.api.campings.Camping;
+import com.bytser.campso.api.facilities.Facility;
+import com.bytser.campso.api.plans.Plan;
+import com.bytser.campso.api.reviews.Review;
 import com.bytser.campso.api.users.CountryCode;
 import com.bytser.campso.api.users.Language;
 import com.bytser.campso.api.users.User;
@@ -31,7 +36,47 @@ public final class TestDataFactory {
         return user;
     }
 
+    public static Activity newActivity() {
+        return new TestActivity();
+    }
+
+    public static Camping newCamping() {
+        return new TestCamping();
+    }
+
+    public static Facility newFacility() {
+        return new TestFacility();
+    }
+
+    public static Plan newPlan() {
+        return new TestPlan();
+    }
+
+    public static Review newReview() {
+        return new TestReview();
+    }
+
     private static class TestUser extends User {
         // Uses the protected no-arg constructor from User
+    }
+
+    private static class TestActivity extends Activity {
+        // Exposes the protected no-arg constructor for tests
+    }
+
+    private static class TestCamping extends Camping {
+        // Exposes the protected no-arg constructor for tests
+    }
+
+    private static class TestFacility extends Facility {
+        // Exposes the protected no-arg constructor for tests
+    }
+
+    private static class TestPlan extends Plan {
+        // Exposes the protected no-arg constructor for tests
+    }
+
+    private static class TestReview extends Review {
+        // Exposes the protected no-arg constructor for tests
     }
 }

--- a/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
+++ b/src/test/java/com/bytser/campso/api/support/TestDataFactory.java
@@ -8,6 +8,8 @@ import com.bytser.campso.api.reviews.Review;
 import com.bytser.campso.api.users.CountryCode;
 import com.bytser.campso.api.users.Language;
 import com.bytser.campso.api.users.User;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -25,7 +27,7 @@ public final class TestDataFactory {
     }
 
     public static User createUser(String identifier) {
-        TestUser user = new TestUser();
+        User user = instantiate(User.class);
         user.setUserName("user" + identifier);
         user.setFirstName("First" + identifier);
         user.setLastName("Last" + identifier);
@@ -37,46 +39,33 @@ public final class TestDataFactory {
     }
 
     public static Activity newActivity() {
-        return new TestActivity();
+        return instantiate(Activity.class);
     }
 
     public static Camping newCamping() {
-        return new TestCamping();
+        return instantiate(Camping.class);
     }
 
     public static Facility newFacility() {
-        return new TestFacility();
+        return instantiate(Facility.class);
     }
 
     public static Plan newPlan() {
-        return new TestPlan();
+        return instantiate(Plan.class);
     }
 
     public static Review newReview() {
-        return new TestReview();
+        return instantiate(Review.class);
     }
 
-    private static class TestUser extends User {
-        // Uses the protected no-arg constructor from User
-    }
-
-    private static class TestActivity extends Activity {
-        // Exposes the protected no-arg constructor for tests
-    }
-
-    private static class TestCamping extends Camping {
-        // Exposes the protected no-arg constructor for tests
-    }
-
-    private static class TestFacility extends Facility {
-        // Exposes the protected no-arg constructor for tests
-    }
-
-    private static class TestPlan extends Plan {
-        // Exposes the protected no-arg constructor for tests
-    }
-
-    private static class TestReview extends Review {
-        // Exposes the protected no-arg constructor for tests
+    private static <T> T instantiate(Class<T> type) {
+        try {
+            Constructor<T> constructor = type.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                | InvocationTargetException exception) {
+            throw new IllegalStateException("Failed to instantiate " + type.getName(), exception);
+        }
     }
 }

--- a/src/test/java/com/bytser/campso/api/users/UserRepositoryTest.java
+++ b/src/test/java/com/bytser/campso/api/users/UserRepositoryTest.java
@@ -1,30 +1,85 @@
 package com.bytser.campso.api.users;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.bytser.campso.api.support.TestDataFactory;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
-public class UserRepositoryTest {
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=create-drop")
+class UserRepositoryTest {
 
-    @BeforeEach
-    @SuppressWarnings("unused") // compiler gives warning that function is never used, but function is used by Spring Boot annotations (@BeforeEach)
-    void setUp() {
-        // Prepare the needed objects or others before executing the tests
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    @DisplayName("findByEmail should return the user with the requested email")
+    void shouldFindUserByEmail() {
+        User storedUser = persistUser("100");
+
+        Optional<User> result = userRepository.findByEmail("user100@example.com");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(storedUser.getId());
+        assertThat(result.get().getEmail()).isEqualTo("user100@example.com");
     }
 
     @Test
-    @DisplayName("This is a example test, tests should be implemented correctly")
-    void ExampleTest() {
-        // Arrange
-        //object.setDurationSeconds(60);
+    @DisplayName("findByEmail should return an empty Optional when the email is unknown")
+    void shouldReturnEmptyOptionalWhenEmailUnknown() {
+        persistUser("200");
 
-        // Act
-        //String durationCategory = object.getDurationCategory();
+        Optional<User> result = userRepository.findByEmail("missing@example.com");
 
-        // Assert
-        assertEquals("TEST", "EXAMPLE", "This is a example test and will not work.");
+        assertThat(result).isNotPresent();
     }
 
+    @Test
+    @DisplayName("findByUserName should resolve the correct user")
+    void shouldFindUserByUserName() {
+        User storedUser = persistUser("300");
+
+        Optional<User> result = userRepository.findByUserName("user300");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(storedUser.getId());
+        assertThat(result.get().getUserName()).isEqualTo("user300");
+    }
+
+    @Test
+    @DisplayName("findByFirstNameAndLastName should return all matching users")
+    void shouldFindUsersByFirstAndLastName() {
+        User firstMatch = persistUser("400");
+        firstMatch.setFirstName("Alex");
+        firstMatch.setLastName("Walker");
+        entityManager.persistAndFlush(firstMatch);
+
+        User secondMatch = persistUser("401");
+        secondMatch.setFirstName("Alex");
+        secondMatch.setLastName("Walker");
+        entityManager.persistAndFlush(secondMatch);
+
+        persistUser("402"); // Different names - should be ignored
+
+        entityManager.clear();
+
+        List<User> result = userRepository.findByFirstNameAndLastName("Alex", "Walker");
+
+        assertThat(result)
+            .extracting(User::getId)
+            .containsExactlyInAnyOrder(firstMatch.getId(), secondMatch.getId());
+    }
+
+    private User persistUser(String identifier) {
+        User user = TestDataFactory.createUser(identifier);
+        return entityManager.persistAndFlush(user);
+    }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,5 +2,7 @@ spring.datasource.url=jdbc:h2:mem:campso;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALS
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+server.port=0
+media.storage.location=build/test-media

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,8 +1,9 @@
-spring.datasource.url=jdbc:h2:mem:campso;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.username=sa
-spring.datasource.password=
+DB_URL=jdbc:h2:mem:campso;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+DB_USERNAME=sa
+DB_PASSWORD=
+STORAGE_LOC=build/test-media
+API_PORT=0
 spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-server.port=0
-media.storage.location=build/test-media
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## Summary
- add DataJpaTest-based integration suites for activity, camping, facility, place, plan, review, and user repositories
- exercise finder methods with realistic entity graphs and spatial data to verify positive and negative scenarios

## Testing
- `./mvnw test` *(fails: Maven wrapper cannot download Maven distribution because external network access is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166e2eb9d0832590f404a80e0be2c5)